### PR TITLE
Allow sending of error notifications to channels

### DIFF
--- a/lib/slack_error_notifier/slack_configuration.rb
+++ b/lib/slack_error_notifier/slack_configuration.rb
@@ -37,7 +37,7 @@ module SlackErrorNotifier
 
     def check_channel_exists
       channels = slack_client.channels_list.channels
-      matching_channel = channels.detect { |c| c.name == target_channel.gsub('#', '') }
+      channels.detect { |c| c.name == target_channel.gsub('#', '') }
     end
 
     def configure_slack_client

--- a/lib/slack_error_notifier/slack_notification.rb
+++ b/lib/slack_error_notifier/slack_notification.rb
@@ -13,7 +13,7 @@ module SlackErrorNotifier
         channel: target_channel,
         text: "",
         attachments: attachments,
-        as_user: true
+        as_user: target_channel.include?('@')
       )
     end
 

--- a/lib/slack_error_notifier/slack_notification.rb
+++ b/lib/slack_error_notifier/slack_notification.rb
@@ -13,7 +13,7 @@ module SlackErrorNotifier
         channel: target_channel,
         text: "",
         attachments: attachments,
-        as_user: target_channel.include?('@')
+        as_user: send_as_user
       )
     end
 


### PR DESCRIPTION
Was getting an error trying to notify a channel instead of a specific user. Apparently if you publish to a channel with the current setup then `as_user` must be false.  
